### PR TITLE
[feat] 이전 작업들 Member Entity 연결 + 오류 수정

### DIFF
--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentController.java
@@ -2,16 +2,13 @@ package com.example.LifeMaster_BE.Community.Comment;
 
 import com.example.LifeMaster_BE.Community.Comment.Dto.AllCommentsDto;
 import com.example.LifeMaster_BE.Community.Comment.Dto.CommentDto;
-import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
-import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
+import com.example.LifeMaster_BE.Security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Parameter;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,19 +20,14 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
-    private final MemberRepository memberRepository;
 
     @GetMapping
     public ResponseEntity<List<AllCommentsDto>> getAllComments(
             @Parameter(description = "게시글 ID", required = true)
             @PathVariable(name = "postId") Long postId,
-            @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal CustomUserDetails user) {
 
-        String email = user.getUsername();
-        MemberEntity member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(email));
-
-        List<AllCommentsDto> allComments = commentService.getAllComments(member.getId(), postId);
+        List<AllCommentsDto> allComments = commentService.getAllComments(user.getId(), postId);
         return ResponseEntity.ok(allComments);
     }
 
@@ -43,9 +35,11 @@ public class CommentController {
     public ResponseEntity<CommentEntity> newComment(
             @Parameter(description = "게시글 ID", required = true)
             @PathVariable("postId") Long postId,
-            @RequestBody CommentDto commentDto){
+            @RequestBody CommentDto commentDto,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
         String comment = commentDto.getComment();
-        CommentEntity createdComment = commentService.createComment(postId, comment);
+        CommentEntity createdComment = commentService.createComment(user.getId(), postId, comment);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(createdComment);
     }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentController.java
@@ -60,6 +60,6 @@ public class CommentController {
             @PathVariable("postId") Long postId,
             @Parameter(description = "댓글 ID", required = true)
             @PathVariable("commentId") Long commentId){
-        commentService.deleteComment(postId, commentId);
+        commentService.deleteComment(commentId);
     }
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentEntity.java
@@ -6,6 +6,7 @@ import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -30,17 +31,19 @@ public class CommentEntity {
     private LocalDateTime commentDate;
 
     // 작성자 연결
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private MemberEntity member;
 
     // 게시글 연결
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private PostEntity post;
 
     // 좋아요
-    @OneToMany(mappedBy = "comment")
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommentLikeEntity> likes = new ArrayList<>();
 
     public void updateComment(String newComment) {
@@ -50,9 +53,13 @@ public class CommentEntity {
 
         this.comment = newComment;
     }
-    public CommentEntity(String comment, PostEntity post, MemberEntity member) {
+
+    public void addLike(CommentLikeEntity like) {
+        this.likes.add(like);
+        like.setComment(this);
+    }
+    public CommentEntity(String comment, PostEntity post) {
         this.comment = comment;
         this.post = post;
-        this.member = member;
     }
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentEntity.java
@@ -2,6 +2,7 @@ package com.example.LifeMaster_BE.Community.Comment;
 
 import com.example.LifeMaster_BE.Community.Comment.Like.CommentLikeEntity;
 import com.example.LifeMaster_BE.Community.Post.PostEntity;
+import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,15 +29,19 @@ public class CommentEntity {
     @CreatedDate
     private LocalDateTime commentDate;
 
-    @OneToMany(mappedBy = "comment")
-    private List<CommentLikeEntity> likes = new ArrayList<>();
+    // 작성자 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
 
     // 게시글 연결
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private PostEntity post;
 
-    // 작성자 연결
+    // 좋아요
+    @OneToMany(mappedBy = "comment")
+    private List<CommentLikeEntity> likes = new ArrayList<>();
 
     public void updateComment(String newComment) {
         if (newComment == null || newComment.isBlank()){
@@ -45,8 +50,9 @@ public class CommentEntity {
 
         this.comment = newComment;
     }
-    public CommentEntity(String comment, PostEntity post) {
+    public CommentEntity(String comment, PostEntity post, MemberEntity member) {
         this.comment = comment;
         this.post = post;
+        this.member = member;
     }
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
@@ -64,8 +64,11 @@ public class CommentService {
         PostEntity post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("post not found"));
 
-        CommentEntity commentEntity = new CommentEntity(comment, post, member);
-        commentRepository.save(commentEntity);
+        CommentEntity commentEntity = new CommentEntity(comment, post);
+
+        member.addComment(commentEntity);
+        post.addComment(commentEntity);
+        commentRepository.save(commentEntity);      // 제거 가능 - 변경감지
         post.increaseCommentCount();
 
         return commentEntity;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
@@ -5,6 +5,8 @@ import com.example.LifeMaster_BE.Community.Comment.Like.CommentLikeEntity;
 import com.example.LifeMaster_BE.Community.Comment.Like.CommentLikeRepository;
 import com.example.LifeMaster_BE.Community.Post.PostEntity;
 import com.example.LifeMaster_BE.Community.Post.PostRepository;
+import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
+import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentLikeRepository likeRepository;
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
     public List<AllCommentsDto> getAllComments(Long memberId, Long postId){
         // 전체 댓글 가져오기
@@ -52,11 +55,16 @@ public class CommentService {
                 ))
                 .toList();
     }
-    public CommentEntity createComment(Long postId, String comment) {
+
+    public CommentEntity createComment(Long memberId, Long postId, String comment) {
+
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("member not found"));
+
         PostEntity post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("post not found"));
 
-        CommentEntity commentEntity = new CommentEntity(comment, post);
+        CommentEntity commentEntity = new CommentEntity(comment, post, member);
         return commentRepository.save(commentEntity);
     }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
@@ -65,7 +65,10 @@ public class CommentService {
                 .orElseThrow(() -> new EntityNotFoundException("post not found"));
 
         CommentEntity commentEntity = new CommentEntity(comment, post, member);
-        return commentRepository.save(commentEntity);
+        commentRepository.save(commentEntity);
+        post.increaseCommentCount();
+
+        return commentEntity;
     }
 
     public void updateComment(Long commentId, Long postId, String comment){
@@ -76,7 +79,12 @@ public class CommentService {
         commentRepository.save(commentEntity);
     }
 
-    public void deleteComment(Long commentId, Long postId){
-        commentRepository.deleteByIdAndPostId(commentId, postId);
+    public void deleteComment(Long commentId){
+        CommentEntity comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("comment not found"));
+        PostEntity post = comment.getPost();
+        post.decreaseCommentCount();
+
+        commentRepository.delete(comment);
     }
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Like/CommentLikeController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Like/CommentLikeController.java
@@ -1,5 +1,6 @@
 package com.example.LifeMaster_BE.Community.Comment.Like;
 
+import com.example.LifeMaster_BE.Security.CustomUserDetails;
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,17 +25,13 @@ public class CommentLikeController {
     private final CommentLikeService likeService;
     private final MemberRepository memberRepository;
 
-//    @Parameter(description = "댓글 ID", required = true) // Swagger 설명 추가
     @PostMapping("/{commentId}")
     public ResponseEntity<Map<String, Boolean>> like(
             @Parameter(description = "댓글 ID", required = true)
             @PathVariable("commentId") Long commentId,
-            @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal CustomUserDetails user) {
 
-        String email = user.getUsername();
-        MemberEntity member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(email));
-        boolean isLiked = likeService.toggleLike(member.getId(), commentId);
+        boolean isLiked = likeService.toggleLike(user.getId(), commentId);
         Map<String, Boolean> response = new HashMap<>();
         response.put("liked", isLiked);
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Like/CommentLikeController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Like/CommentLikeController.java
@@ -1,14 +1,11 @@
 package com.example.LifeMaster_BE.Community.Comment.Like;
 
 import com.example.LifeMaster_BE.Security.CustomUserDetails;
-import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import io.swagger.v3.oas.annotations.Parameter;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Like/CommentLikeEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Like/CommentLikeEntity.java
@@ -4,9 +4,11 @@ import com.example.LifeMaster_BE.Community.Comment.CommentEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Entity
+@Setter
 @NoArgsConstructor
 @Table(name = "comment_likes", uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "comment_id"}))
 public class CommentLikeEntity {
@@ -18,12 +20,12 @@ public class CommentLikeEntity {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
+    @Setter
     @ManyToOne
     @JoinColumn(name = "comment_id", nullable = false)
     private CommentEntity comment;
 
-    public CommentLikeEntity(Long memberId, CommentEntity comment) {
+    public CommentLikeEntity(Long memberId) {
         this.memberId = memberId;
-        this.comment = comment;
     }
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Like/CommentLikeService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Like/CommentLikeService.java
@@ -17,19 +17,19 @@ public class CommentLikeService {
     private final CommentLikeRepository likeRepository;
     private final CommentRepository commentRepository;
 
-    public boolean toggleLike(Long memberID, Long commentId){
+    public boolean toggleLike(Long memberId, Long commentId){
 
-        Optional<CommentLikeEntity> existingLike = likeRepository.findByMemberIdAndCommentId(memberID, commentId);
+        Optional<CommentLikeEntity> existingLike = likeRepository.findByMemberIdAndCommentId(memberId, commentId);
 
         if(existingLike.isPresent()){
-            likeRepository.deleteByMemberIdAndCommentId(memberID, commentId);
+            likeRepository.deleteByMemberIdAndCommentId(memberId, commentId);
             return false;
         } else {
             CommentEntity comment = commentRepository.findById(commentId)
                     .orElseThrow(() -> new EntityNotFoundException("Comment Not found"));
 
-            CommentLikeEntity newLike = new CommentLikeEntity(memberID, comment);
-
+            CommentLikeEntity newLike = new CommentLikeEntity(memberId);
+            comment.addLike(newLike);
             likeRepository.save(newLike);
             return true;
         }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Dto/AllPostsDto.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Dto/AllPostsDto.java
@@ -14,6 +14,7 @@ public class AllPostsDto {
     private String title;
     private String nickName;
     private int viewCount;
+    private int commentCount;
     private LocalDateTime createdAt;
     private boolean liked;
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Like/PostLikeController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Like/PostLikeController.java
@@ -1,14 +1,10 @@
 package com.example.LifeMaster_BE.Community.Post.Like;
 
 import com.example.LifeMaster_BE.Security.CustomUserDetails;
-import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
-import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import io.swagger.v3.oas.annotations.Parameter;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Like/PostLikeController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Like/PostLikeController.java
@@ -1,5 +1,6 @@
 package com.example.LifeMaster_BE.Community.Post.Like;
 
+import com.example.LifeMaster_BE.Security.CustomUserDetails;
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,19 +23,14 @@ import java.util.Map;
 public class PostLikeController {
 
     private final PostLikeService likeService;
-    private final MemberRepository memberRepository;
 
     @PostMapping("/{postId}")
     public ResponseEntity<Map<String, Boolean>> like (
             @Parameter(description = "게시글 ID", required = true)
             @PathVariable("postId") Long postId,
-            @AuthenticationPrincipal User user){
+            @AuthenticationPrincipal CustomUserDetails user){
 
-        String email = user.getUsername();
-        MemberEntity member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(email));
-
-        boolean isLiked = likeService.toggleLike(member.getId(), postId);
+        boolean isLiked = likeService.toggleLike(user.getId(), postId);
         Map<String, Boolean> response = new HashMap<>();
         response.put("liked", isLiked);
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Like/PostLikeEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Like/PostLikeEntity.java
@@ -4,6 +4,7 @@ import com.example.LifeMaster_BE.Community.Post.PostEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -18,12 +19,12 @@ public class PostLikeEntity {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
+    @Setter
     @ManyToOne
     @JoinColumn(name = "post_id", nullable = false)
     private PostEntity post;
 
-    public PostLikeEntity(Long memberId, PostEntity post) {
+    public PostLikeEntity(Long memberId) {
         this.memberId = memberId;
-        this.post = post;
     }
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Like/PostLikeService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Like/PostLikeService.java
@@ -28,8 +28,8 @@ public class PostLikeService {
             PostEntity post = postRepository.findById(postId)
                     .orElseThrow(() -> new EntityNotFoundException("Post Not found"));
 
-            PostLikeEntity newLike = new PostLikeEntity(memberId, post);
-
+            PostLikeEntity newLike = new PostLikeEntity(memberId);
+            post.addLike(newLike);
             likeRepository.save(newLike);
             return true;
         }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
@@ -3,10 +3,7 @@ package com.example.LifeMaster_BE.Community.Post;
 import com.example.LifeMaster_BE.Community.Post.Dto.AllPostsDto;
 import com.example.LifeMaster_BE.Community.Post.Dto.PostDto;
 import com.example.LifeMaster_BE.Security.CustomUserDetails;
-import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
-import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +18,6 @@ import java.util.List;
 public class PostController {
 
     private final PostService postService;
-    private final MemberRepository memberRepository;
 
     @Operation(summary = "게시글 전체 조회", description = "특정 유형(type)의 게시글 목록을 조회합니다.")
     @GetMapping
@@ -36,17 +32,13 @@ public class PostController {
     @PostMapping
     public ResponseEntity<PostEntity> newPost(@RequestBody PostDto postDto,
                                               @AuthenticationPrincipal CustomUserDetails user) {
-        String email = user.getUsername();
+        Long memberId = user.getId();
         String title = postDto.getTitle();
         String content = postDto.getContent();
         String fileUrl = postDto.getFile();
         PostType type = postDto.getType();
 
-        MemberEntity member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(email));
-
-
-        PostEntity post = postService.createPost(title, content, fileUrl, type, member);
+        PostEntity post = postService.createPost(title, content, fileUrl, type, memberId);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(post);
     }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
@@ -2,6 +2,7 @@ package com.example.LifeMaster_BE.Community.Post;
 
 import com.example.LifeMaster_BE.Community.Post.Dto.AllPostsDto;
 import com.example.LifeMaster_BE.Community.Post.Dto.PostDto;
+import com.example.LifeMaster_BE.Security.CustomUserDetails;
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,19 +25,17 @@ public class PostController {
 
     @Operation(summary = "게시글 전체 조회", description = "특정 유형(type)의 게시글 목록을 조회합니다.")
     @GetMapping
-    public ResponseEntity<List<AllPostsDto>> getAllPosts(@RequestParam("type") PostType type, @AuthenticationPrincipal User user) {
+    public ResponseEntity<List<AllPostsDto>> getAllPosts(@RequestParam("type") PostType type,
+                                                         @AuthenticationPrincipal CustomUserDetails user) {
 
-        String email = user.getUsername();
-        MemberEntity member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(email));
-
-        List<AllPostsDto> allPosts = postService.getAllPosts(member.getId(), type);
+        List<AllPostsDto> allPosts = postService.getAllPosts(user.getId(), type);
         return ResponseEntity.ok(allPosts);
     }
 
     @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
     @PostMapping
-    public ResponseEntity<PostEntity> newPost(@RequestBody PostDto postDto, @AuthenticationPrincipal User user) {
+    public ResponseEntity<PostEntity> newPost(@RequestBody PostDto postDto,
+                                              @AuthenticationPrincipal CustomUserDetails user) {
         String email = user.getUsername();
         String title = postDto.getTitle();
         String content = postDto.getContent();
@@ -63,15 +61,13 @@ public class PostController {
     @Operation(summary = "게시글 수정", description = "게시글 ID를 통해 특정 게시글을 수정합니다.")
     @PatchMapping("/{postId}")
     public void updatePost(@PathVariable Long postId,
-                           @RequestBody PostDto postDto, @AuthenticationPrincipal User user){
+                           @RequestBody PostDto postDto,
+                           @AuthenticationPrincipal CustomUserDetails user){
         String title = postDto.getTitle();
         String content = postDto.getContent();
         String fileUrl = postDto.getFile();
-        String email = user.getUsername();
-        MemberEntity member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(email));
 
-        postService.updatePost(postId, title, content, fileUrl, member.getId());
+        postService.updatePost(postId, title, content, fileUrl, user.getId());
     }
 
     @Operation(summary = "게시글 삭제", description = "게시글 ID를 통해 특정 게시글을 삭제합니다.")

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostEntity.java
@@ -56,10 +56,6 @@ public class PostEntity {
         this.file = fileUrl;
     }
 
-    public void increaseViewCount() {
-        this.viewCount++;
-    }
-
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now(); // 현재 시간을 자동으로 설정

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostEntity.java
@@ -6,6 +6,7 @@ import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -32,24 +33,24 @@ public class PostEntity {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private MemberEntity member;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostLikeEntity> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommentEntity> comments = new ArrayList<>();
 
     private int commentCount = 0;
 
-    public PostEntity(String title, String content, String file, PostType type, MemberEntity member) {
+    public PostEntity(String title, String content, String file, PostType type) {
         this.title = title;
         this.content = content;
         this.file = file;
         this.type = type;
-        this.member = member;
     }
 
     public void updatePost(String title, String content, String fileUrl) {
@@ -68,6 +69,15 @@ public class PostEntity {
         }
     }
 
+    public void addComment(CommentEntity comment) {
+        this.comments.add(comment);
+        comment.setPost(this);
+    }
+
+    public void addLike(PostLikeEntity like) {
+        this.likes.add(like);
+        like.setPost(this);
+    }
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now(); // 현재 시간을 자동으로 설정

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostEntity.java
@@ -42,6 +42,8 @@ public class PostEntity {
     @OneToMany(mappedBy = "post")
     private List<CommentEntity> comments = new ArrayList<>();
 
+    private int commentCount = 0;
+
     public PostEntity(String title, String content, String file, PostType type, MemberEntity member) {
         this.title = title;
         this.content = content;
@@ -54,6 +56,16 @@ public class PostEntity {
         this.title = title;
         this.content = content;
         this.file = fileUrl;
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        if (this.commentCount > 0) {
+            this.commentCount--;
+        }
     }
 
     @PrePersist

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostRepository.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostRepository.java
@@ -3,6 +3,7 @@ package com.example.LifeMaster_BE.Community.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -15,7 +16,7 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
     @Modifying
     @Transactional
     @Query("UPDATE PostEntity p SET p.viewCount = p.viewCount + 1 WHERE p.id = :postId")
-    void increaseViewCount(Long postId);
+    void increaseViewCount(@Param("postId") Long postId);
 
     // 조회수 기준 인기글 상위 2개 가져오기
     List<PostEntity> findTop2ByOrderByViewCountDesc();

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostService.java
@@ -4,6 +4,7 @@ import com.example.LifeMaster_BE.Community.Post.Dto.AllPostsDto;
 import com.example.LifeMaster_BE.Community.Post.Like.PostLikeEntity;
 import com.example.LifeMaster_BE.Community.Post.Like.PostLikeRepository;
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
+import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -23,6 +24,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final PostLikeRepository likeRepository;
+    private final MemberRepository memberRepository;
     private final RedisTemplate<String, Object> redisTemplate;
 
     private static final String POPULAR_POSTS_KEY = "popularPosts"; // 인기글 캐싱 키
@@ -63,8 +65,13 @@ public class PostService {
     }
 
     public PostEntity createPost(String title, String content, String fileUrl,
-                                 PostType type, MemberEntity member) {
-        PostEntity postEntity = new PostEntity(title, content, fileUrl, type, member);
+                                 PostType type, Long memberId) {
+
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found"));
+
+        PostEntity postEntity = new PostEntity(title, content, fileUrl, type);
+        member.addPost(postEntity);
         return postRepository.save(postEntity);
     }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostService.java
@@ -45,6 +45,7 @@ public class PostService {
                         post.getTitle(),
                         post.getMember().getNickname(),
                         post.getViewCount(),
+                        post.getCommentCount(),
                         post.getCreatedAt(),
                         likedPostIds.contains(post.getId())
                 ))

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostService.java
@@ -54,8 +54,9 @@ public class PostService {
     public PostEntity getPost(Long postId){
         PostEntity post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("Post not found"));
-        post.increaseViewCount();
-        getPostCount(postId);
+
+        // 게시글 조회 시 조회수 증가 (DB 반영)
+        postRepository.increaseViewCount(postId);
         postRepository.save(post); // 변경 감지를 위한 저장
         return post;
     }
@@ -76,15 +77,6 @@ public class PostService {
 
     public void deletePost(Long postId){
         postRepository.deleteById(postId);
-    }
-
-    // 게시글 조회 시 조회수 증가 (DB 반영)
-    @Transactional
-    public PostEntity getPostCount(Long postId) {
-        PostEntity post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
-        postRepository.increaseViewCount(postId); // 조회수 증가
-        return post;
     }
 
     // 인기글 갱신 (Redis에 저장)

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/LifeMasterBeApplication.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/LifeMasterBeApplication.java
@@ -1,17 +1,17 @@
 package com.example.LifeMaster_BE;
 
-import com.example.LifeMaster_BE.FunctionManager.ToDoList.TodoEntity;
-import org.antlr.v4.runtime.misc.LogManager;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import com.example.LifeMaster_BE.FunctionManager.ToDoList.TodoRepository;
 import com.example.LifeMaster_BE.FunctionManager.ToDoList.TodoService;
+
 @SpringBootApplication  // Spring Boot 애플리케이션 설정
 @RestController
+@EnableJpaAuditing
 public class LifeMasterBeApplication {
 
 	private final TodoService todoService;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/calendar/SelfDevelopCalendarController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/calendar/SelfDevelopCalendarController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Slf4j
 @RestController("selfDevelopCalendarController")
@@ -20,7 +20,7 @@ public class SelfDevelopCalendarController {
     // ISO 8601 형식(yyyy-MM-dd 또는 yyyy-MM-dd'T'HH:mm:ss) 아닌 경우
     // @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME
     @GetMapping
-    public EventDto getEvent(@RequestParam("date") LocalDateTime date){
+    public EventDto getEvent(@RequestParam("date") LocalDate date){
         return calendarService.getEventsByDate(date);
     }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/calendar/SelfDevelopCalendarService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/calendar/SelfDevelopCalendarService.java
@@ -7,7 +7,7 @@ import com.example.LifeMaster_BE.SelfDevelop.note.thank.ThankRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Service("selfDevelopCalendarService")
 @RequiredArgsConstructor
@@ -16,7 +16,7 @@ public class SelfDevelopCalendarService {
     private final DiaryRepository diaryRepository;
     private final ThankRepository thankRepository;
 
-    public EventDto getEventsByDate(LocalDateTime date){
+    public EventDto getEventsByDate(LocalDate date){
         DiaryEntity diary = diaryRepository.findByDiaryDate(date);
         ThankEntity thank = thankRepository.findByThankDate(date);
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryController.java
@@ -1,9 +1,11 @@
 package com.example.LifeMaster_BE.SelfDevelop.note.diary;
 
+import com.example.LifeMaster_BE.Security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -14,14 +16,13 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
-    /**
-     * DiaryEntity 관련 매서드
-     * User id 처리가 필요(session or client 측에서)
-     */
-
     @PostMapping
-    public ResponseEntity<DiaryEntity> newDiary(@RequestBody DiaryEntity diary) {
-        DiaryEntity createdDiary = diaryService.createDiary(diary);
+    public ResponseEntity<DiaryEntity> newDiary(
+            @RequestBody DiaryEntity diary,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        Long memberId = user.getId();
+        DiaryEntity createdDiary = diaryService.createDiary(diary, memberId);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdDiary);
     }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryController.java
@@ -38,6 +38,7 @@ public class DiaryController {
     @DeleteMapping("/{diary-id}")
     public ResponseEntity<Void> deleteDiary(
             @PathVariable("diary-id") Long diaryId){
+
         diaryService.deleteDiary(diaryId);
         return ResponseEntity.noContent().build();
     }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryEntity.java
@@ -1,5 +1,6 @@
 package com.example.LifeMaster_BE.SelfDevelop.note.diary;
 
+import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import jakarta.persistence.*;
 import lombok.Data;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -20,11 +21,10 @@ public class DiaryEntity {
     @Lob
     private String diaryContent;
 
-    // 추후에 User 엔티티가 추가된다면
-    /*
+    // Member
     @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
-     */
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
+
 
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryEntity.java
@@ -3,8 +3,10 @@ package com.example.LifeMaster_BE.SelfDevelop.note.diary;
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import jakarta.persistence.*;
 import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -16,10 +18,14 @@ public class DiaryEntity {
     @GeneratedValue
     private Long id;
 
-    private LocalDateTime diaryDate;
-
     @Lob
     private String diaryContent;
+
+    private LocalDate diaryDate;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
 
     // Member
     @ManyToOne

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryRepository.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryRepository.java
@@ -2,10 +2,10 @@ package com.example.LifeMaster_BE.SelfDevelop.note.diary;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
 
-    DiaryEntity findByDiaryDate(LocalDateTime diaryDate);
+    DiaryEntity findByDiaryDate(LocalDate date);
 
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryService.java
@@ -18,9 +18,9 @@ public class DiaryService {
     private final MemberRepository memberRepository;
 
     public DiaryEntity createDiary(DiaryEntity diary, Long memberId){
+
         MemberEntity member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("Member not found"));
-
         member.addDiary(diary);
         return diaryRepository.save(diary);
     }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryService.java
@@ -1,5 +1,8 @@
 package com.example.LifeMaster_BE.SelfDevelop.note.diary;
 
+import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
+import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +15,13 @@ import org.springframework.stereotype.Service;
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
+    private final MemberRepository memberRepository;
 
-    public DiaryEntity createDiary(DiaryEntity diary){
+    public DiaryEntity createDiary(DiaryEntity diary, Long memberId){
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found"));
+
+        member.addDiary(diary);
         return diaryRepository.save(diary);
     }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankController.java
@@ -1,9 +1,11 @@
 package com.example.LifeMaster_BE.SelfDevelop.note.thank;
 
+import com.example.LifeMaster_BE.Security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -16,8 +18,11 @@ public class ThankController {
 
     @PostMapping
     public ResponseEntity<ThankEntity> newThank(
-            @RequestBody ThankEntity thank){
-        ThankEntity createdThank = thankService.createThank(thank);
+            @RequestBody ThankEntity thank,
+            @AuthenticationPrincipal CustomUserDetails user){
+
+        Long memberId = user.getId();
+        ThankEntity createdThank = thankService.createThank(thank, memberId);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdThank);
     }
 
@@ -25,6 +30,7 @@ public class ThankController {
     public ResponseEntity<ThankEntity> editThank(
             @RequestBody ThankUpdateDto thankDto,
             @PathVariable("thank-id") Long thankId){
+
         ThankEntity updatedThank = thankService.editDiary(thankId, thankDto);
         return ResponseEntity.ok(updatedThank);
     }
@@ -32,6 +38,7 @@ public class ThankController {
     @DeleteMapping("/{thank-id}")
     public ResponseEntity<Void> deleteThank(
             @PathVariable("thank-id") Long thankId){
+
         thankService.deleteDiary(thankId);
         return ResponseEntity.noContent().build();
     }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankController.java
@@ -20,7 +20,6 @@ public class ThankController {
     public ResponseEntity<ThankEntity> newThank(
             @RequestBody ThankEntity thank,
             @AuthenticationPrincipal CustomUserDetails user){
-
         Long memberId = user.getId();
         ThankEntity createdThank = thankService.createThank(thank, memberId);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdThank);
@@ -30,7 +29,6 @@ public class ThankController {
     public ResponseEntity<ThankEntity> editThank(
             @RequestBody ThankUpdateDto thankDto,
             @PathVariable("thank-id") Long thankId){
-
         ThankEntity updatedThank = thankService.editDiary(thankId, thankDto);
         return ResponseEntity.ok(updatedThank);
     }
@@ -38,7 +36,6 @@ public class ThankController {
     @DeleteMapping("/{thank-id}")
     public ResponseEntity<Void> deleteThank(
             @PathVariable("thank-id") Long thankId){
-
         thankService.deleteDiary(thankId);
         return ResponseEntity.noContent().build();
     }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankEntity.java
@@ -1,5 +1,6 @@
 package com.example.LifeMaster_BE.SelfDevelop.note.thank;
 
+import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import jakarta.persistence.*;
 import lombok.Data;
 import org.springframework.data.annotation.CreatedDate;
@@ -28,11 +29,8 @@ public class ThankEntity {
     private String thankFour;
     private String thankFive;
 
-    // 추후에 User 엔티티가 추가된다면
-    /*
     @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
-     */
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
 
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankEntity.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -18,7 +19,7 @@ public class ThankEntity {
     private Long id;
 
 //    @CreatedDate
-    private LocalDateTime thankDate;
+    private LocalDate thankDate;
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankRepository.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankRepository.java
@@ -2,9 +2,9 @@ package com.example.LifeMaster_BE.SelfDevelop.note.thank;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public interface ThankRepository extends JpaRepository<ThankEntity, Long> {
 
-    ThankEntity findByThankDate(LocalDateTime thankDate);
+    ThankEntity findByThankDate(LocalDate date);
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankService.java
@@ -1,5 +1,8 @@
 package com.example.LifeMaster_BE.SelfDevelop.note.thank;
 
+import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
+import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +15,13 @@ import org.springframework.stereotype.Service;
 public class ThankService {
 
     private final ThankRepository thankRepository;
+    private final MemberRepository memberRepository;
 
-    public ThankEntity createThank(ThankEntity thank){
+    public ThankEntity createThank(ThankEntity thank, Long memberId){
+
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found"));
+        member.addThank(thank);
         return thankRepository.save(thank);
     }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Register/RegisterController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Register/RegisterController.java
@@ -34,12 +34,13 @@ public class RegisterController {
 
     @PostMapping("/nickname")
     public ResponseEntity<String> registerNickname(@ModelAttribute RegisterWithNicknameDto registerWithNicknameDto) {
+        Long id = registerWithNicknameDto.getId();
         String nickName = registerWithNicknameDto.getNickName();
         MultipartFile image = registerWithNicknameDto.getImage();
 
         System.out.println("nickName:" + nickName);
 
-        registerService.registerMemberWithNickname(nickName, image);
+        registerService.registerMemberWithNickname(id, nickName, image);
         return ResponseEntity.ok("saved successfully");
     }
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Register/RegisterService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Register/RegisterService.java
@@ -31,12 +31,12 @@ public class RegisterService {
         return memberRepository.save(memberEntity);
     }
 
-    public void registerMemberWithNickname(String nickname, MultipartFile image){
+    public void registerMemberWithNickname(Long id, String nickname, MultipartFile image){
         if(checkNicknameDuplicate(nickname)){
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
-        MemberEntity memberEntity = memberRepository.findByNickname(nickname)
+        MemberEntity memberEntity = memberRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다"));
 
         memberEntity.setNickname(nickname);

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Register/RegisterWithNicknameDto.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Register/RegisterWithNicknameDto.java
@@ -6,6 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 public class RegisterWithNicknameDto {
 
+    private Long id;
     private String nickName;
     private MultipartFile image;
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
@@ -2,6 +2,8 @@ package com.example.LifeMaster_BE.UserManager.Member;
 
 import com.example.LifeMaster_BE.Community.Comment.CommentEntity;
 import com.example.LifeMaster_BE.Group.GroupEntity;
+import com.example.LifeMaster_BE.SelfDevelop.note.diary.DiaryEntity;
+import com.example.LifeMaster_BE.SelfDevelop.note.thank.ThankEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.example.LifeMaster_BE.Community.Post.PostEntity;
 import jakarta.persistence.*;
@@ -64,6 +66,14 @@ public class MemberEntity {
     // 댓글
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<CommentEntity> comments = new ArrayList<>();
+
+    // 5감사
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<ThankEntity> thanks = new ArrayList<>();
+
+    // 일기
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<DiaryEntity> diaries = new ArrayList<>();
 
     public MemberEntity(String email, String password) {
         this.email = email;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
@@ -1,5 +1,6 @@
 package com.example.LifeMaster_BE.UserManager.Member;
 
+import com.example.LifeMaster_BE.Community.Comment.CommentEntity;
 import com.example.LifeMaster_BE.Group.GroupEntity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.example.LifeMaster_BE.Community.Post.PostEntity;
@@ -60,6 +61,9 @@ public class MemberEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<PostEntity> posts = new ArrayList<>();
 
+    // 댓글
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<CommentEntity> comments = new ArrayList<>();
 
     public MemberEntity(String email, String password) {
         this.email = email;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
@@ -101,5 +101,29 @@ public class MemberEntity {
         this.loginStatus = bool;
         return this;
     }
+
+    // 게시글
+    public void addPost(PostEntity post) {
+        this.posts.add(post);
+        post.setMember(this);
+    }
+
+    // 댓글
+    public void addComment(CommentEntity comment) {
+        this.comments.add(comment);
+        comment.setMember(this);
+    }
+
+    // 5감사
+    public void addThank(ThankEntity thank) {
+        this.thanks.add(thank);
+        thank.setMember(this);
+    }
+
+    // 일기
+    public void addDiary(DiaryEntity diary) {
+        this.diaries.add(diary);
+        diary.setMember(this);
+    }
 }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
@@ -60,19 +60,19 @@ public class MemberEntity {
     private Set<GroupEntity> groups = new HashSet<>(); // 그룹 목록
     
     // 게시글
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostEntity> posts = new ArrayList<>();
 
     // 댓글
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommentEntity> comments = new ArrayList<>();
 
     // 5감사
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ThankEntity> thanks = new ArrayList<>();
 
     // 일기
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DiaryEntity> diaries = new ArrayList<>();
 
     public MemberEntity(String email, String password) {


### PR DESCRIPTION
### CustomUserDetails
- CustomUserDetails 각 Controller에 전부 도입

### 연관관계 구현 수정
- 기존에 일대다 연결에서 "일"쪽 엔티티 List에 "다"쪽 엔티티를 추가해야 하는 부분이 전부 누락되어 있음.
- 해당 부분 수정

### Member 연결
- 5감사 / 일기 엔티티 Member 엔티티 연결 누락
- 엔티티 연결 이후에 연결 설정에 필요한 부분 구현