### PR TITLE
[hotfix] CommentEntity 필드명 변경 Service에 적용

### DIFF
--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
@@ -50,7 +50,7 @@ public class CommentService {
                 .map(comment -> new AllCommentsDto(
                         "Comment 작성한 사람(comment.getMember.getEmail?)",
                         comment.getComment(),
-                        comment.getCommentDate(),
+                        comment.getCreatedAt(),
                         likedCommentIds.contains(comment.getId())
                 ))
                 .toList();


### PR DESCRIPTION
### 수정사항
- 이전에 CommentEntity의 필드명 수정(commentDate -> createdAt)을 Service에 적용하지 않음