### PR TITLE
게시글 관련 프론트 요청사항 +  댓글 리팩토링

### DIFF
--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentController.java
@@ -1,7 +1,7 @@
 package com.example.LifeMaster_BE.Community.Comment;
 
 import com.example.LifeMaster_BE.Community.Comment.Dto.AllCommentsDto;
-import com.example.LifeMaster_BE.Community.Comment.Dto.CommentDto;
+import com.example.LifeMaster_BE.Community.Comment.Dto.CommentCreateRequest;
 import com.example.LifeMaster_BE.Security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -32,16 +33,16 @@ public class CommentController {
     }
 
     @PostMapping
-    public ResponseEntity<CommentEntity> newComment(
+    public ResponseEntity<Map<String, Long>> newComment(
             @Parameter(description = "게시글 ID", required = true)
             @PathVariable("postId") Long postId,
-            @RequestBody CommentDto commentDto,
+            @RequestBody CommentCreateRequest commentDto,
             @AuthenticationPrincipal CustomUserDetails user) {
 
         String comment = commentDto.getComment();
         CommentEntity createdComment = commentService.createComment(user.getId(), postId, comment);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdComment);
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("commentId", createdComment.getId()));
     }
 
     @PatchMapping("/{commentId}")
@@ -50,7 +51,7 @@ public class CommentController {
             @PathVariable("postId") Long postId,
             @Parameter(description = "댓글 ID", required = true)
             @PathVariable("commentId") Long commentId,
-            @RequestBody CommentDto commentDto){
+            @RequestBody CommentCreateRequest commentDto){
         commentService.updateComment(commentId, postId, commentDto.getComment());
     }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentRepository.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentRepository.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
     void deleteByIdAndPostId(Long commentId, Long postId);
     Optional<CommentEntity> findByIdAndPostId(Long commentId, Long postId);
+
+    @EntityGraph(attributePaths = {"member"})
     List<CommentEntity> findByPostId(Long postId);
 
     @EntityGraph(attributePaths = {"post"})

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/CommentService.java
@@ -48,7 +48,7 @@ public class CommentService {
 
         return comments.stream()
                 .map(comment -> new AllCommentsDto(
-                        "Comment 작성한 사람(comment.getMember.getEmail?)",
+                        comment.getMember().getNickname(),
                         comment.getComment(),
                         comment.getCreatedAt(),
                         likedCommentIds.contains(comment.getId())

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Dto/CommentCreateRequest.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Comment/Dto/CommentCreateRequest.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class CommentDto {
+public class CommentCreateRequest {
 
     private String comment;
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Dto/PostCreateRequest.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Dto/PostCreateRequest.java
@@ -1,0 +1,17 @@
+package com.example.LifeMaster_BE.Community.Post.Dto;
+
+import com.example.LifeMaster_BE.Community.Post.PostType;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Data
+@NoArgsConstructor
+public class PostCreateRequest {
+
+    private String title;
+    private String content;
+    private String file;
+    private PostType type;
+}

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Dto/PostCreateRequest.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Dto/PostCreateRequest.java
@@ -2,9 +2,7 @@ package com.example.LifeMaster_BE.Community.Post.Dto;
 
 import com.example.LifeMaster_BE.Community.Post.PostType;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Data
 @NoArgsConstructor

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Dto/PostGetResponse.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/Dto/PostGetResponse.java
@@ -1,14 +1,14 @@
 package com.example.LifeMaster_BE.Community.Post.Dto;
 
 import com.example.LifeMaster_BE.Community.Post.PostType;
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
+@Data
 @NoArgsConstructor
-public class PostDto {
+@AllArgsConstructor
+public class PostGetResponse {
 
     private String title;
     private String content;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
@@ -45,14 +45,14 @@ public class PostController {
 
     @Operation(summary = "게시글 조회", description = "게시글 ID를 통해 단일 게시글을 조회합니다.")
     @GetMapping("/{postId}")
-    public ResponseEntity<PostEntity> getPost(@PathVariable Long postId){
+    public ResponseEntity<PostEntity> getPost(@PathVariable("postId") Long postId){
         PostEntity post = postService.getPost(postId);
         return ResponseEntity.ok(post);
     }
 
     @Operation(summary = "게시글 수정", description = "게시글 ID를 통해 특정 게시글을 수정합니다.")
     @PatchMapping("/{postId}")
-    public void updatePost(@PathVariable Long postId,
+    public void updatePost(@PathVariable("postId") Long postId,
                            @RequestBody PostDto postDto,
                            @AuthenticationPrincipal CustomUserDetails user){
         String title = postDto.getTitle();
@@ -64,7 +64,7 @@ public class PostController {
 
     @Operation(summary = "게시글 삭제", description = "게시글 ID를 통해 특정 게시글을 삭제합니다.")
     @DeleteMapping("/{postId}")
-    public void deletePost(@PathVariable Long postId){
+    public void deletePost(@PathVariable("postId") Long postId){
         postService.deletePost(postId);
     }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/posts")
@@ -30,7 +31,7 @@ public class PostController {
 
     @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
     @PostMapping
-    public ResponseEntity<PostEntity> newPost(@RequestBody PostDto postDto,
+    public ResponseEntity<Map<String, Long>> newPost(@RequestBody PostDto postDto,
                                               @AuthenticationPrincipal CustomUserDetails user) {
         Long memberId = user.getId();
         String title = postDto.getTitle();
@@ -40,7 +41,7 @@ public class PostController {
 
         PostEntity post = postService.createPost(title, content, fileUrl, type, memberId);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(post);
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("postId", post.getId()));
     }
 
     @Operation(summary = "게시글 조회", description = "게시글 ID를 통해 단일 게시글을 조회합니다.")

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostController.java
@@ -1,7 +1,8 @@
 package com.example.LifeMaster_BE.Community.Post;
 
 import com.example.LifeMaster_BE.Community.Post.Dto.AllPostsDto;
-import com.example.LifeMaster_BE.Community.Post.Dto.PostDto;
+import com.example.LifeMaster_BE.Community.Post.Dto.PostCreateRequest;
+import com.example.LifeMaster_BE.Community.Post.Dto.PostGetResponse;
 import com.example.LifeMaster_BE.Security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class PostController {
 
     @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
     @PostMapping
-    public ResponseEntity<Map<String, Long>> newPost(@RequestBody PostDto postDto,
+    public ResponseEntity<Map<String, Long>> newPost(@RequestBody PostCreateRequest postDto,
                                               @AuthenticationPrincipal CustomUserDetails user) {
         Long memberId = user.getId();
         String title = postDto.getTitle();
@@ -46,15 +47,21 @@ public class PostController {
 
     @Operation(summary = "게시글 조회", description = "게시글 ID를 통해 단일 게시글을 조회합니다.")
     @GetMapping("/{postId}")
-    public ResponseEntity<PostEntity> getPost(@PathVariable("postId") Long postId){
+    public ResponseEntity<PostGetResponse> getPost(@PathVariable("postId") Long postId){
         PostEntity post = postService.getPost(postId);
-        return ResponseEntity.ok(post);
+        PostGetResponse response = new PostGetResponse(
+                post.getTitle(),
+                post.getContent(),
+                post.getFile(),
+                post.getType()
+        );
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "게시글 수정", description = "게시글 ID를 통해 특정 게시글을 수정합니다.")
     @PatchMapping("/{postId}")
     public void updatePost(@PathVariable("postId") Long postId,
-                           @RequestBody PostDto postDto,
+                           @RequestBody PostCreateRequest postDto,
                            @AuthenticationPrincipal CustomUserDetails user){
         String title = postDto.getTitle();
         String content = postDto.getContent();


### PR DESCRIPTION
### 요청사항
- 게시글 생성, 단건 조회시 PostEntity 객체 자체를 반환하기 때문에 응답 body 내용이 너무 많아짐.
- DTO를 활용해서 필요한 필드만 반환
### 리팩토링
- 특정 게시글의 댓글 전체 조회 시 작성자를 임의의 값 -> 실제 작성자 nickname으로 변경
- 이 때 발생할 수 있는 N+1 문제를 방지하기 위해 findByPostId 매서드에 MemberEntitiy에 대한 fetch join 적용