### PR TITLE
챌린지 인원수 측정 오류 수정

### DIFF
--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Challenge/Challenge.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Challenge/Challenge.java
@@ -40,9 +40,4 @@ public class Challenge extends BaseEntity {
     @Column
     @Builder.Default
     private Integer challCnt = 1;
-
-    // 챌린지 날짜 (시작일 or 생성일)
-    @Getter
-    @Column(nullable = false)
-    private LocalDate challDate;
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Challenge/ChallengeController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Challenge/ChallengeController.java
@@ -125,7 +125,7 @@ public class ChallengeController {
         // 1) 삭제 전: 챌린지 조회(본인 것만) + 날짜 확보
         Challenge challenge = challengeService.getChallengeByIdAndMemberId(challId, memberId);
 
-        LocalDate challDate = challenge.getChallDate();
+        LocalDate challDate = challenge.getCreatedAt().toLocalDate();
         String dateKey = challDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 
         // 2) 챌린지 삭제 (권한 포함)

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Challenge/ChallengeService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Challenge/ChallengeService.java
@@ -119,7 +119,7 @@ public class ChallengeService {
                 .user(user)
                 .build();
 
-
+        challengeRepository.save(updatedChallenge);
         challengeUserRepository.save(challengeUser);
 
         return "챌린지 참여 완료!";
@@ -209,10 +209,10 @@ public class ChallengeService {
         Challenge challenge = challengeRepository.findById(challId)
                 .orElseThrow(() -> new EntityNotFoundException("Challenge not found: " + challId));
 
-        if (challenge.getChallDate() == null) {
+        if (challenge.getCreatedAt() == null) {
             throw new IllegalStateException("challDate가 null입니다. challId=" + challId);
         }
-        return challenge.getChallDate(); // LocalDate
+        return challenge.getCreatedAt().toLocalDate(); // LocalDate
     }
 
     public long countJoinedChallengesOnDate(Long memberId, String yyyyMMdd) {


### PR DESCRIPTION
## 오류  
- 챌린지 인원수 변수가 있으나, 참가를 해도 늘어나지 않는 오류 발생
- challDate 가 NotNull 로 추가되어 기존 createdAt 이 있음에도 중복 추가 및 notnull 문제로 기존 데이터와 충돌 오류 발생

## 수정
- 챌린지 참여 시 challCnt 자동 추가 할 수 있게 save 처리 해줌  
- challDate 변수 제거 및 관련 부분 createdAt으로 전부 변경 