### PR TITLE
fix: 캘린더 조회 시 일기/감사 모두 필수 조건 제거

### DIFF
--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/calendar/SelfDevelopCalendarService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/calendar/SelfDevelopCalendarService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Service("selfDevelopCalendarService")
 @Transactional
@@ -21,23 +22,25 @@ public class SelfDevelopCalendarService {
 
     public CalendarDailyContentDto getEventsByDate(LocalDate date){
 
-        DiaryEntity diary = diaryRepository.findByDiaryDate(date)
-                .orElseThrow(() -> new EntityNotFoundException("Diary not found"));
-        ThankEntity thank = thankRepository.findByThankDate(date)
-                .orElseThrow(() -> new EntityNotFoundException("Thank not found"));
+        Optional<DiaryEntity> diary = diaryRepository.findByDiaryDate(date);
+        Optional<ThankEntity> thank = thankRepository.findByThankDate(date);
 
-        return convertToDto(diary, thank);
+        if (diary.isEmpty() && thank.isEmpty()) {
+            throw new EntityNotFoundException("해당 날짜에 작성된 일기 또는 감사 기록이 없습니다.");
+        }
+
+        return convertToDto(diary.orElse(null), thank.orElse(null));
     }
 
     public CalendarDailyContentDto convertToDto(DiaryEntity diary, ThankEntity thank) {
         return new CalendarDailyContentDto(
-                diary.getId(),
-                thank.getId(),
-                diary.getDiaryContent(),
-                thank.getThankOne(),
-                thank.getThankTwo(),
-                thank.getThankThree(),
-                thank.getThankFour(),
-                thank.getThankFive());
+                diary != null ? diary.getId() : null,
+                thank != null ? thank.getId() : null,
+                diary != null ? diary.getDiaryContent() : null,
+                thank != null ? thank.getThankOne() : null,
+                thank != null ? thank.getThankTwo() : null,
+                thank != null ? thank.getThankThree() : null,
+                thank != null ? thank.getThankFour() : null,
+                thank != null ? thank.getThankFive() : null);
     }
 }


### PR DESCRIPTION
### 작업 내용
- 캘린더 조회 시 일기와 5감사를 모두 작성해야만 조회 가능했던 로직을 하나만 작성해도 조회 가능하도록 수정                                                                                                                       
- SelfDevelopCalendarService에서 orElseThrow → Optional 조회로 변경, 둘 다 없을 때만 예외 발생                                                                                                                                  
- 작성하지 않은 항목의 필드는 null로 반환   