### PR TITLE
fix: 관리자 신고 관리 기능 개선

### DIFF
--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Admin/Report/AdminReportService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Admin/Report/AdminReportService.java
@@ -4,6 +4,7 @@ import com.example.LifeMaster_BE.Admin.Report.Dto.AdminReportDetailDto;
 import com.example.LifeMaster_BE.Admin.Report.Dto.AdminReportListDto;
 import com.example.LifeMaster_BE.Admin.Report.Dto.ReportActionRequest;
 import com.example.LifeMaster_BE.Admin.Report.Dto.ReportStatusUpdateRequest;
+import com.example.LifeMaster_BE.Community.Post.PostEntity;
 import com.example.LifeMaster_BE.Community.Post.PostRepository;
 import com.example.LifeMaster_BE.Report.ReportActionType;
 import com.example.LifeMaster_BE.Report.ReportEntity;
@@ -62,11 +63,30 @@ public class AdminReportService {
         MemberEntity admin = memberRepository.findByEmail(adminEmail)
                 .orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다. Email: " + adminEmail));
 
-        // 신고 처리
-        report.resolve(admin, ReportStatus.RESOLVED, request.getActionType(), request.getAdminNote());
+        System.out.println("=== 신고 처리 시작 ===");
+        System.out.println("Report ID: " + reportId);
+        System.out.println("Admin Email: " + adminEmail);
+        System.out.println("Admin ID: " + admin.getId());
+        System.out.println("Action Type: " + request.getActionType());
+
+        // 신고 처리 (반려는 REJECTED 상태로, 나머지는 RESOLVED)
+        ReportStatus targetStatus = (request.getActionType() == ReportActionType.REJECT)
+                ? ReportStatus.REJECTED
+                : ReportStatus.RESOLVED;
+        report.resolve(admin, targetStatus, request.getActionType(), request.getAdminNote());
+
+        System.out.println("resolve 호출 후:");
+        System.out.println("Report Status: " + report.getStatus());
+        System.out.println("ResolvedBy: " + (report.getResolvedBy() != null ? report.getResolvedBy().getId() : "null"));
+        System.out.println("ResolvedBy Nickname: " + (report.getResolvedBy() != null ? report.getResolvedBy().getNickname() : "null"));
 
         // 조치 적용
         applyAction(report, request.getActionType());
+
+        System.out.println("applyAction 호출 후:");
+        System.out.println("Report Status: " + report.getStatus());
+        System.out.println("ResolvedBy: " + (report.getResolvedBy() != null ? report.getResolvedBy().getId() : "null"));
+        System.out.println("=== 신고 처리 완료 ===");
     }
 
     private void applyAction(ReportEntity report, ReportActionType actionType) {
@@ -80,12 +100,21 @@ public class AdminReportService {
         }
 
         switch (actionType) {
+            case REJECT:
+                // 반려는 별도 조치 없음
+                break;
             case WARNING:
                 postAuthor.setWarningCount(postAuthor.getWarningCount() + 1);
                 postAuthor.setMemberStatus(MemberStatus.WARNED);
                 break;
             case POST_DELETE:
-                postRepository.delete(report.getPost());
+                PostEntity postToDelete = report.getPost();
+                // 게시글 삭제 전에 모든 신고에 게시글 정보 스냅샷 저장
+                postToDelete.getReports().forEach(r -> {
+                    r.savePostSnapshot(postToDelete);
+                    r.setPost(null);  // 연관관계 해제
+                });
+                postRepository.delete(postToDelete);
                 break;
             case SUSPEND_1D:
             case SUSPEND_7D:

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Admin/Report/Dto/AdminReportDetailDto.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Admin/Report/Dto/AdminReportDetailDto.java
@@ -52,14 +52,14 @@ public class AdminReportDetailDto {
                 .reporterId(report.getMember() != null ? report.getMember().getId() : null)
                 .reporterNickname(report.getMember() != null ? report.getMember().getNickname() : null)
                 .reporterEmail(report.getMember() != null ? report.getMember().getEmail() : null)
-                // 게시글 정보
-                .postId(report.getPost() != null ? report.getPost().getId() : null)
-                .postTitle(report.getPost() != null ? report.getPost().getTitle() : null)
-                .postContent(report.getPost() != null ? report.getPost().getContent() : null)
+                // 게시글 정보 (post가 있으면 엔티티에서, 없으면 스냅샷에서)
+                .postId(report.getPost() != null ? report.getPost().getId() : report.getPostIdSnapshot())
+                .postTitle(report.getPost() != null ? report.getPost().getTitle() : report.getPostTitle())
+                .postContent(report.getPost() != null ? report.getPost().getContent() : report.getPostContent())
                 .postAuthorId(report.getPost() != null && report.getPost().getMember() != null
-                        ? report.getPost().getMember().getId() : null)
+                        ? report.getPost().getMember().getId() : report.getPostAuthorId())
                 .postAuthorNickname(report.getPost() != null && report.getPost().getMember() != null
-                        ? report.getPost().getMember().getNickname() : null)
+                        ? report.getPost().getMember().getNickname() : report.getPostAuthorNickname())
                 // 처리 정보
                 .resolvedById(report.getResolvedBy() != null ? report.getResolvedBy().getId() : null)
                 .resolvedByNickname(report.getResolvedBy() != null ? report.getResolvedBy().getNickname() : null)

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Admin/Report/Dto/AdminReportListDto.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Admin/Report/Dto/AdminReportListDto.java
@@ -31,8 +31,8 @@ public class AdminReportListDto {
                 .status(report.getStatus())
                 .reporterId(report.getMember() != null ? report.getMember().getId() : null)
                 .reporterNickname(report.getMember() != null ? report.getMember().getNickname() : null)
-                .postId(report.getPost() != null ? report.getPost().getId() : null)
-                .postTitle(report.getPost() != null ? report.getPost().getTitle() : null)
+                .postId(report.getPost() != null ? report.getPost().getId() : report.getPostIdSnapshot())
+                .postTitle(report.getPost() != null ? report.getPost().getTitle() : report.getPostTitle())
                 .createdAt(report.getCreatedAt())
                 .build();
     }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Community/Post/PostEntity.java
@@ -56,7 +56,7 @@ public class PostEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostLikeEntity> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<ReportEntity> reports = new ArrayList<>();
 
     private int commentCount = 0;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Report/ReportActionType.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Report/ReportActionType.java
@@ -4,6 +4,7 @@ package com.example.LifeMaster_BE.Report;
  * 신고 처리 조치 유형을 나타내는 ENUM
  */
 public enum ReportActionType {
+    REJECT,        // 반려
     WARNING,       // 경고
     POST_DELETE,   // 게시글 삭제
     SUSPEND_1D,    // 1일 정지

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Report/ReportEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Report/ReportEntity.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(
+@Table(name = "report_entity",
         indexes = {
                 @Index(name = "idx_report_member_post", columnList = "member_id, post_id")
         }
@@ -39,6 +39,23 @@ public class ReportEntity {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
+    // 게시글 정보 스냅샷 (게시글 삭제 시에도 정보 보존)
+    @Column(name = "post_id_snapshot")
+    private Long postIdSnapshot;
+
+    @Column(name = "post_title")
+    private String postTitle;
+
+    @Lob
+    @Column(name = "post_content")
+    private String postContent;
+
+    @Column(name = "post_author_id")
+    private Long postAuthorId;
+
+    @Column(name = "post_author_nickname")
+    private String postAuthorNickname;
+
     // 관리자 기능용 필드
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
@@ -62,6 +79,17 @@ public class ReportEntity {
         this.member = member;
         this.post = post;
         this.reason = reason;
+
+        // 게시글 정보 스냅샷 저장 (삭제 시에도 정보 보존)
+        if (post != null) {
+            this.postIdSnapshot = post.getId();
+            this.postTitle = post.getTitle();
+            this.postContent = post.getContent();
+            if (post.getMember() != null) {
+                this.postAuthorId = post.getMember().getId();
+                this.postAuthorNickname = post.getMember().getNickname();
+            }
+        }
     }
 
     public void resolve(MemberEntity admin, ReportStatus status, ReportActionType actionType, String adminNote) {
@@ -74,5 +102,17 @@ public class ReportEntity {
 
     public void updateStatus(ReportStatus status) {
         this.status = status;
+    }
+
+    public void savePostSnapshot(PostEntity post) {
+        if (post != null) {
+            this.postIdSnapshot = post.getId();
+            this.postTitle = post.getTitle();
+            this.postContent = post.getContent();
+            if (post.getMember() != null) {
+                this.postAuthorId = post.getMember().getId();
+                this.postAuthorNickname = post.getMember().getNickname();
+            }
+        }
     }
 }

--- a/LifeMaster-BE/src/main/resources/static/js/admin/admin-reports.js
+++ b/LifeMaster-BE/src/main/resources/static/js/admin/admin-reports.js
@@ -171,13 +171,15 @@ function renderReportDetail(report) {
 
             <div class="detail-section">
                 <h4>처리 정보</h4>
-                ${report.resolvedByNickname ? `
-                    <p><strong>처리자:</strong> ${report.resolvedByNickname} (ID: ${report.resolvedById})</p>
+                ${(report.status === "RESOLVED" || report.status === "REJECTED") && report.resolvedById ? `
+                    <p><strong>처리자:</strong> ${report.resolvedByNickname || '관리자'} (ID: ${report.resolvedById})</p>
                     <p><strong>조치:</strong> ${reportActionBadge(report.actionType)}</p>
                     <p><strong>관리자 메모:</strong> ${report.adminNote ?? "-"}</p>
                     <p><strong>처리 일시:</strong> ${formatDateTime(report.resolvedAt)}</p>
+                ` : report.status === "REVIEWING" ? `
+                    <p style="color: #007bff; font-weight: bold;">검토 중</p>
                 ` : `
-                    <p style="color: #999;">아직 처리되지 않았습니다.</p>
+                    <p style="color: #999; font-weight: bold;">대기 중</p>
                 `}
             </div>
         </div>
@@ -189,7 +191,6 @@ function renderReportDetail(report) {
                     <select id="status-select-${report.id}" class="status-select">
                         <option value="PENDING" ${report.status === "PENDING" ? "selected" : ""}>대기 중</option>
                         <option value="REVIEWING" ${report.status === "REVIEWING" ? "selected" : ""}>검토 중</option>
-                        <option value="REJECTED" ${report.status === "REJECTED" ? "selected" : ""}>반려됨</option>
                     </select>
                     <button class="btn-action" onclick="updateReportStatus(${report.id})">상태 변경</button>
                 </div>
@@ -197,6 +198,7 @@ function renderReportDetail(report) {
                 <div class="action-group">
                     <h4>조치 실행</h4>
                     <select id="action-select-${report.id}" class="action-select">
+                        <option value="REJECT">반려</option>
                         <option value="WARNING">경고</option>
                         <option value="POST_DELETE">게시글 삭제</option>
                         <option value="SUSPEND_1D">1일 정지</option>
@@ -338,6 +340,8 @@ function reportActionBadge(actionType) {
     if (!actionType) return "-";
 
     switch (actionType) {
+        case "REJECT":
+            return `<span class="badge gray">반려</span>`;
         case "WARNING":
             return `<span class="badge yellow">경고</span>`;
         case "POST_DELETE":
@@ -367,6 +371,7 @@ function getStatusText(status) {
 // 조치 텍스트
 function getActionText(actionType) {
     switch (actionType) {
+        case "REJECT": return "반려";
         case "WARNING": return "경고";
         case "POST_DELETE": return "게시글 삭제";
         case "SUSPEND_1D": return "1일 정지";

--- a/LifeMaster-BE/src/main/resources/templates/admin/dashboard.html
+++ b/LifeMaster-BE/src/main/resources/templates/admin/dashboard.html
@@ -244,37 +244,37 @@
                         </table>
                     </div>
                 </div>
-            </div>
 
-            <div class="table-card premium-manage-card">
-                <div class="table-header">
-                    <div>
-                        <h2>일반 회원 프리미엄 부여</h2>
-                        <p>프리미엄 권한이 없는 회원에게 이용권을 부여합니다.</p>
+                <div class="table-card premium-manage-card">
+                    <div class="table-header">
+                        <div>
+                            <h2>일반 회원 프리미엄 부여</h2>
+                            <p>프리미엄 권한이 없는 회원에게 이용권을 부여합니다.</p>
+                        </div>
+
+                        <button onclick="loadNonPremiumMembers(0)">새로고침</button>
                     </div>
 
-                    <button onclick="loadNonPremiumMembers(0)">새로고침</button>
-                </div>
+                    <div class="table-wrap">
+                        <table>
+                            <thead>
+                            <tr>
+                                <th>회원 ID</th>
+                                <th>이메일</th>
+                                <th>이름</th>
+                                <th>부여 기간</th>
+                                <th>작업</th>
+                            </tr>
+                            </thead>
+                            <tbody id="nonPremiumTableBody"></tbody>
+                        </table>
+                    </div>
 
-                <div class="table-wrap">
-                    <table>
-                        <thead>
-                        <tr>
-                            <th>회원 ID</th>
-                            <th>이메일</th>
-                            <th>이름</th>
-                            <th>부여 기간</th>
-                            <th>작업</th>
-                        </tr>
-                        </thead>
-                        <tbody id="nonPremiumTableBody"></tbody>
-                    </table>
-                </div>
-
-                <div class="pagination-box">
-                    <button id="nonPremiumPrevBtn" onclick="prevNonPremiumPage()">이전</button>
-                    <span id="nonPremiumPageInfo">1 / 1</span>
-                    <button id="nonPremiumNextBtn" onclick="nextNonPremiumPage()">다음</button>
+                    <div class="pagination-box">
+                        <button id="nonPremiumPrevBtn" onclick="prevNonPremiumPage()">이전</button>
+                        <span id="nonPremiumPageInfo">1 / 1</span>
+                        <button id="nonPremiumNextBtn" onclick="nextNonPremiumPage()">다음</button>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
### 작업
- 게시글 삭제 시 신고가 함께 삭제되지 않도록 cascade 설정 수정              
- 게시글 삭제 후에도 신고에서 게시글 정보를 볼 수 있도록 스냅샷 필드 추가                                                    
- 신고 처리 정보 표시 오류 수정 (resolvedByNickname 빈 문자열 처리)         
- 반려 처리 워크플로우 개선 (조치 실행 시스템으로 이동하여 관리자 메모 지원)
- 관리자 페이지 HTML 구조 수정 (프리미엄 섹션이 신고 페이지에 표시되는 문제 해결)