### PR TITLE
fix: 일기/5감사 조회 및 수정 시 권한 검증 추가

### DIFF
--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryController.java
@@ -43,8 +43,10 @@ public class DiaryController {
 
     @GetMapping("/{diary-id}")
     public ResponseEntity<DiaryResponse> getDiary(
-            @PathVariable("diary-id") Long diaryId){
-        DiaryResponse diary = diaryService.getDiary(diaryId);
+            @PathVariable("diary-id") Long diaryId,
+            @AuthenticationPrincipal CustomUserDetails user){
+        Long memberId = user.getId();
+        DiaryResponse diary = diaryService.getDiary(diaryId, memberId);
         return ResponseEntity.ok(diary);
     }
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/diary/DiaryService.java
@@ -32,9 +32,9 @@ public class DiaryService {
         return diaryRepository.save(newDiary);
     }
 
-    public DiaryResponse getDiary(Long diaryId){
-        DiaryEntity diary = diaryRepository.findById(diaryId)
-                .orElseThrow(() -> new EntityNotFoundException("Diary not found"));
+    public DiaryResponse getDiary(Long diaryId, Long memberId){
+        DiaryEntity diary = diaryRepository.findByIdAndMember_Id(diaryId, memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Diary not found or no permission"));
 
         return DiaryResponse.builder()
                 .diaryContent(diary.getDiaryContent())

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankController.java
@@ -43,8 +43,10 @@ public class ThankController {
 
     @GetMapping("/{thank-id}")
     public ResponseEntity<ThankResponse> getThank(
-            @PathVariable("thank-id") Long thankId){
-        ThankResponse thank = thankService.getThank(thankId);
+            @PathVariable("thank-id") Long thankId,
+            @AuthenticationPrincipal CustomUserDetails user){
+        Long memberId = user.getId();
+        ThankResponse thank = thankService.getThank(thankId, memberId);
         return ResponseEntity.ok(thank);
     }
 
@@ -55,7 +57,7 @@ public class ThankController {
             @AuthenticationPrincipal CustomUserDetails user) {
         Long memberId = user.getId();
 
-        ThankEntity updatedThank = thankService.updateThank(thankId, thankDto);
+        ThankEntity updatedThank = thankService.updateThank(thankId, thankDto, memberId);
 
         // Thank의 실제 날짜 기준 (String yyyyMMdd)
         String dateKey = updatedThank.getThankDate()

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/SelfDevelop/note/thank/ThankService.java
@@ -33,9 +33,9 @@ public class ThankService {
         return thankRepository.save(newThank);
     }
 
-    public ThankResponse getThank(Long thankId){
-        ThankEntity thank = thankRepository.findById(thankId)
-                .orElseThrow(() -> new EntityNotFoundException("Thank not found"));
+    public ThankResponse getThank(Long thankId, Long memberId){
+        ThankEntity thank = thankRepository.findByIdAndMember_Id(thankId, memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Thank not found or no permission"));
 
         return ThankResponse.builder()
                 .thankOne(thank.getThankOne())
@@ -46,9 +46,9 @@ public class ThankService {
                 .thankDate(thank.getThankDate())
                 .build();
     }
-    public ThankEntity updateThank(Long thankId, UpdateThankDto thankDto){
-        ThankEntity thank = thankRepository.findById(thankId)
-                .orElseThrow(() -> new EntityNotFoundException("Thank not found"));
+    public ThankEntity updateThank(Long thankId, UpdateThankDto thankDto, Long memberId){
+        ThankEntity thank = thankRepository.findByIdAndMember_Id(thankId, memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Thank not found or no permission"));
         return updateThankData(thank, thankDto);
     }
 


### PR DESCRIPTION
- 일기/5감사 조회 API에서 작성자 본인만 조회 가능하도록 권한 검증 추가
- 5감사 수정 API에서 작성자 본인만 수정 가능하도록 권한 검증 추가
- findByIdAndMember_Id 사용하여 다른 사용자의 데이터 접근 차단
- 권한 없는 경우 "not found or no permission" 예외 발생