### PR TITLE
feat: 관리자 신고 처리 시 회원 정지 기능 구현

### DIFF
--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Admin/Report/AdminReportService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Admin/Report/AdminReportService.java
@@ -117,9 +117,13 @@ public class AdminReportService {
                 postRepository.delete(postToDelete);
                 break;
             case SUSPEND_1D:
+                postAuthor.suspend(1);
+                break;
             case SUSPEND_7D:
+                postAuthor.suspend(7);
+                break;
             case SUSPEND_30D:
-                postAuthor.setMemberStatus(MemberStatus.SUSPENDED);
+                postAuthor.suspend(30);
                 break;
         }
     }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Exception/CustomException/MemberSuspendedException.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Exception/CustomException/MemberSuspendedException.java
@@ -1,4 +1,4 @@
-package com.example.LifeMaster_BE.Exception;
+package com.example.LifeMaster_BE.Exception.CustomException;
 
 import java.time.LocalDateTime;
 

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Exception/GlobalExceptionHandler.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.LifeMaster_BE.Exception;
 
 import com.example.LifeMaster_BE.Exception.CustomException.ConflictException;
 import com.example.LifeMaster_BE.Exception.CustomException.ForbiddenActionException;
+import com.example.LifeMaster_BE.Exception.CustomException.MemberSuspendedException;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
@@ -12,7 +13,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.nio.file.AccessDeniedException;
 import java.util.NoSuchElementException;
 
 @RestControllerAdvice

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Exception/GlobalExceptionHandler.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Exception/GlobalExceptionHandler.java
@@ -89,6 +89,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
     }
 
+    @ExceptionHandler(MemberSuspendedException.class)
+    public ResponseEntity<ErrorResponse> handleMemberSuspended(MemberSuspendedException ex) {
+        ErrorResponse body = new ErrorResponse(
+                HttpStatus.FORBIDDEN.value(),
+                ex.getMessage(),
+                System.currentTimeMillis()
+        );
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+    }
+
     @ExceptionHandler(Exception.class) // 최후의 보루
     public ResponseEntity<ErrorResponse> handleAll(Exception ex) {
         // ✅ RSE는 상단 핸들러로 가도록 그대로 던짐 (500으로 덮어쓰지 않음)

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Exception/MemberSuspendedException.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Exception/MemberSuspendedException.java
@@ -1,0 +1,20 @@
+package com.example.LifeMaster_BE.Exception;
+
+import java.time.LocalDateTime;
+
+/**
+ * 회원 정지 상태 예외
+ */
+public class MemberSuspendedException extends RuntimeException {
+
+    private final LocalDateTime suspendedUntil;
+
+    public MemberSuspendedException(LocalDateTime suspendedUntil) {
+        super("계정이 " + suspendedUntil + "까지 정지되었습니다.");
+        this.suspendedUntil = suspendedUntil;
+    }
+
+    public LocalDateTime getSuspendedUntil() {
+        return suspendedUntil;
+    }
+}

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Security/CustomUserDetailService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Security/CustomUserDetailService.java
@@ -1,5 +1,6 @@
 package com.example.LifeMaster_BE.Security;
 
+import com.example.LifeMaster_BE.Exception.MemberSuspendedException;
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import jakarta.transaction.Transactional;
@@ -26,6 +27,11 @@ public class CustomUserDetailService implements UserDetailsService {
 
         MemberEntity member = memberRepository.findByEmail(email)
                 .orElseThrow(() ->  new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+
+        // 정지 상태 체크
+        if (member.isSuspended()) {
+            throw new MemberSuspendedException(member.getSuspendedUntil());
+        }
 
         List<SimpleGrantedAuthority> authorities = List.of(
                 new SimpleGrantedAuthority("ROLE_" + member.getLoginRole().name())

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Security/CustomUserDetailService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Security/CustomUserDetailService.java
@@ -1,12 +1,11 @@
 package com.example.LifeMaster_BE.Security;
 
-import com.example.LifeMaster_BE.Exception.MemberSuspendedException;
+import com.example.LifeMaster_BE.Exception.CustomException.MemberSuspendedException;
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
@@ -76,6 +76,9 @@ public class MemberEntity {
     @Column(name = "warning_count")
     private int warningCount = 0;
 
+    @Column(name = "suspended_until")
+    private LocalDateTime suspendedUntil;
+
     @Column(name = "created_at", updatable = false)
     @CreatedDate
     private LocalDateTime createdAt;
@@ -219,5 +222,27 @@ public class MemberEntity {
         }
 
         return this;
+    }
+
+    // 정지 관련 메서드
+    public void suspend(int days) {
+        this.memberStatus = MemberStatus.SUSPENDED;
+        this.suspendedUntil = LocalDateTime.now().plusDays(days);
+    }
+
+    public void releaseSuspension() {
+        this.memberStatus = MemberStatus.ACTIVE;
+        this.suspendedUntil = null;
+    }
+
+    public boolean isSuspended() {
+        if (this.memberStatus == MemberStatus.SUSPENDED && this.suspendedUntil != null) {
+            if (LocalDateTime.now().isAfter(this.suspendedUntil)) {
+                releaseSuspension();
+                return false;
+            }
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### 작업
- MemberEntity에 suspendedUntil 필드 추가 (정지 해제 시간)
- 1일/7일/30일 정지 처리 로직 구현 (AdminReportService)
- 로그인 시 정지 상태 자동 체크 및 정지 기간 만료 시 자동 해제
- 정지된 회원 로그인 시 MemberSuspendedException 발생
- 정지 종료 시간을 포함한 에러 메시지 반환
