### PR TITLE
feat: 회원 탈퇴 기능 구현 (Soft Delete)  

### DIFF
--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/ETC/MyPage/MyPageService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/ETC/MyPage/MyPageService.java
@@ -19,12 +19,22 @@ public class MyPageService {
         MemberEntity member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("Member Not Found"));
 
+        // 탈퇴한 회원인지 확인
+        if (member.isDeleted()) {
+            throw new IllegalStateException("탈퇴한 회원입니다.");
+        }
+
         return new MyPageDto(member.getId(), member.getNickname(), member.getEmail());
     }
 
     public MyPageDto updateMemberInfo(Long memberId, String nickName, String email){
         MemberEntity member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("Member Not Found"));
+
+        // 탈퇴한 회원인지 확인
+        if (member.isDeleted()) {
+            throw new IllegalStateException("탈퇴한 회원입니다.");
+        }
 
         member.updateByMyPage(nickName, email);
         memberRepository.save(member);
@@ -36,6 +46,8 @@ public class MyPageService {
         MemberEntity member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("Member Not Found"));
 
-        memberRepository.delete(member);
+        // Soft Delete: 회원 탈퇴 처리
+        member.withdraw();
+        memberRepository.save(member);
     }
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Security/CustomUserDetailService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/Security/CustomUserDetailService.java
@@ -3,6 +3,7 @@ package com.example.LifeMaster_BE.Security;
 import com.example.LifeMaster_BE.Exception.CustomException.MemberSuspendedException;
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
+import com.example.LifeMaster_BE.UserManager.Member.MemberStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +25,8 @@ public class CustomUserDetailService implements UserDetailsService {
     @Override
     public CustomUserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-        MemberEntity member = memberRepository.findByEmail(email)
+        // 탈퇴하지 않은 회원만 조회
+        MemberEntity member = memberRepository.findByEmailAndMemberStatusNot(email, MemberStatus.DELETED)
                 .orElseThrow(() ->  new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
 
         // 정지 상태 체크

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Login/LoginService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Login/LoginService.java
@@ -2,6 +2,7 @@ package com.example.LifeMaster_BE.UserManager.Email.Login;
 
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
+import com.example.LifeMaster_BE.UserManager.Member.MemberStatus;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,8 +26,10 @@ public class LoginService {
     }
 
     private boolean checkPassword(String email, String password) {
-        MemberEntity memberEntity = memberRepository.findByEmail(email)
+        // 탈퇴하지 않은 회원만 조회
+        MemberEntity memberEntity = memberRepository.findByEmailAndMemberStatusNot(email, MemberStatus.DELETED)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
         BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
 
         return bCryptPasswordEncoder.matches(password, memberEntity.getPassword());

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Password/PasswordService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Password/PasswordService.java
@@ -2,6 +2,7 @@ package com.example.LifeMaster_BE.UserManager.Email.Password;
 
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
+import com.example.LifeMaster_BE.UserManager.Member.MemberStatus;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,8 @@ public class PasswordService {
     private final TokenService tokenService;
 
     public void sendPasswordResetEmail(String email) {
-        MemberEntity memberEntity = memberRepository.findByEmail(email)
+        // 탈퇴하지 않은 회원만 조회
+        MemberEntity memberEntity = memberRepository.findByEmailAndMemberStatusNot(email, MemberStatus.DELETED)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 이메일 정보입니다."));
 
         String code = tokenService.createVerificationCode(email, memberEntity.getId());
@@ -55,6 +57,11 @@ public class PasswordService {
         Long userId = tokenService.validateAndConsumeToken(token);
         MemberEntity memberEntity = memberRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("Invalid member"));
+
+        // 탈퇴한 회원인지 확인
+        if (memberEntity.isDeleted()) {
+            throw new IllegalStateException("탈퇴한 회원입니다.");
+        }
 
         BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
         String hashedPassword = bCryptPasswordEncoder.encode(newPassword);

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Register/RegisterService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Email/Register/RegisterService.java
@@ -16,6 +16,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import com.example.LifeMaster_BE.UserManager.Member.LoginType;
+import com.example.LifeMaster_BE.UserManager.Member.MemberStatus;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -80,7 +81,8 @@ public class RegisterService {
     }
 
     public boolean checkNicknameAvailable(String nickname){
-        return memberRepository.existsByNickname(nickname);
+        // 탈퇴하지 않은 회원 중에서 닉네임 중복 체크
+        return memberRepository.existsByNicknameAndMemberStatusNot(nickname, MemberStatus.DELETED);
     }
 
     private void checkBeforeRegister(String email, String password, String confirmPassword){
@@ -94,7 +96,8 @@ public class RegisterService {
     }
 
     private boolean checkEmailDuplicate(String email){
-        return memberRepository.existsByEmail(email);
+        // 탈퇴하지 않은 회원 중에서 이메일 중복 체크
+        return memberRepository.existsByEmailAndMemberStatusNot(email, MemberStatus.DELETED);
     }
 
     private boolean confirmPassword(String password, String confirmPassword){

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberEntity.java
@@ -83,6 +83,9 @@ public class MemberEntity {
     @CreatedDate
     private LocalDateTime createdAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     // Many-to-Many 관계 추가
     @ManyToMany
     @JsonIgnore
@@ -244,5 +247,16 @@ public class MemberEntity {
             return true;
         }
         return false;
+    }
+
+    // 회원 탈퇴 관련 메서드
+    public void withdraw() {
+        this.memberStatus = MemberStatus.DELETED;
+        this.loginStatus = false;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.memberStatus == MemberStatus.DELETED;
     }
 }

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberRepository.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Member/MemberRepository.java
@@ -19,6 +19,12 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String Email);
 
+    // 탈퇴하지 않은 회원 조회 메서드 (일반 사용자용)
+    boolean existsByNicknameAndMemberStatusNot(String nickname, MemberStatus status);
+    boolean existsByEmailAndMemberStatusNot(String email, MemberStatus status);
+    Optional<MemberEntity> findByEmailAndMemberStatusNot(String email, MemberStatus status);
+
+    // 기존 메서드 (관리자용 - 탈퇴 회원 포함)
     Optional<MemberEntity> findByEmail(String email);
     @Query("SELECT m.email FROM MemberEntity m WHERE m.id = :id")
     Optional<String> findEmailById(@Param("id") Long id);

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Peristalsis/CustomOAuth2UserService.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Peristalsis/CustomOAuth2UserService.java
@@ -28,6 +28,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import com.example.LifeMaster_BE.UserManager.Member.LoginType;
+import com.example.LifeMaster_BE.UserManager.Member.MemberStatus;
 
 import java.time.Instant;
 import java.util.*;
@@ -173,7 +174,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         MemberEntity member = new MemberEntity(user.getEmail(), user.getIdentifier());
         member.setLoginType(LoginType.GOOGLE);
 
-        Optional<MemberEntity> existing = memberRepository.findByEmail(user.getEmail());
+        // 탈퇴하지 않은 회원만 조회
+        Optional<MemberEntity> existing = memberRepository.findByEmailAndMemberStatusNot(user.getEmail(), MemberStatus.DELETED);
 
         if (existing.isEmpty()) {
             String baseNickname = resolveNickname(
@@ -237,7 +239,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             MemberEntity member = new MemberEntity(user.getEmail(),user.getIdentifier());
             member.setLoginType(LoginType.NAVER);
 
-            Optional<MemberEntity> existing = memberRepository.findByEmail(user.getEmail());
+            // 탈퇴하지 않은 회원만 조회
+            Optional<MemberEntity> existing = memberRepository.findByEmailAndMemberStatusNot(user.getEmail(), MemberStatus.DELETED);
 
             if (existing.isEmpty()) {
                 String baseNickname = resolveNickname(
@@ -454,7 +457,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     }
 
     private MemberEntity saveOrUpdateMember(MemberEntity usersEntity) {
-        MemberEntity user = memberRepository.findByEmail(usersEntity.getEmail())
+        // 탈퇴하지 않은 회원만 조회
+        MemberEntity user = memberRepository.findByEmailAndMemberStatusNot(usersEntity.getEmail(), MemberStatus.DELETED)
                 .map(entity -> entity.updateOAuthInfo(
                         usersEntity.getPicture(),
                         usersEntity.getNickname(),
@@ -474,7 +478,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         String nickname = baseNickname;
         int suffix = 1;
 
-        while (memberRepository.existsByNickname(nickname)) {
+        // 탈퇴하지 않은 회원 중에서 닉네임 중복 체크
+        while (memberRepository.existsByNicknameAndMemberStatusNot(nickname, MemberStatus.DELETED)) {
             nickname = baseNickname + "_" + suffix++;
         }
         return nickname;

--- a/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Peristalsis/Kakao/AuthController.java
+++ b/LifeMaster-BE/src/main/java/com/example/LifeMaster_BE/UserManager/Peristalsis/Kakao/AuthController.java
@@ -5,6 +5,7 @@ import com.example.LifeMaster_BE.UserManager.Member.LoginRole;
 import com.example.LifeMaster_BE.UserManager.Member.LoginType;
 import com.example.LifeMaster_BE.UserManager.Member.MemberEntity;
 import com.example.LifeMaster_BE.UserManager.Member.MemberRepository;
+import com.example.LifeMaster_BE.UserManager.Member.MemberStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -47,8 +48,8 @@ public class AuthController {
                 return ResponseEntity.status(400).body(Map.of("message", "사용자 이메일이 없습니다."));
             }
 
-            // 3. DB 조회 혹은 신규 생성
-            MemberEntity user = memberRepository.findByEmail(email).orElseGet(() -> {
+            // 3. DB 조회 혹은 신규 생성 (탈퇴하지 않은 회원만)
+            MemberEntity user = memberRepository.findByEmailAndMemberStatusNot(email, MemberStatus.DELETED).orElseGet(() -> {
                 MemberEntity newUser = MemberEntity.builder()
                         .email(email)
                         .nickname(nickname)
@@ -85,7 +86,8 @@ public class AuthController {
             // JwtUtil로 email 추출
             String email = jwtUtil.extractEmail(refreshToken);
 
-            MemberEntity user = memberRepository.findByEmail(email)
+            // 탈퇴하지 않은 회원만 조회
+            MemberEntity user = memberRepository.findByEmailAndMemberStatusNot(email, MemberStatus.DELETED)
                     .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + email));
 
             String newAccessToken = jwtUtil.generateToken(user.getEmail());

--- a/LifeMaster-BE/src/test/java/com/example/LifeMaster_BE/ETC/MyPage/MyPageServiceTest.java
+++ b/LifeMaster-BE/src/test/java/com/example/LifeMaster_BE/ETC/MyPage/MyPageServiceTest.java
@@ -93,7 +93,8 @@ class MyPageServiceTest {
 
         myPageService.deleteMemberInfo(memberId);
 
-        verify(memberRepository).delete(member);
+        // Soft delete이므로 save() 호출됨
+        verify(memberRepository).save(member);
     }
 
     @Test


### PR DESCRIPTION
### Summary

- 회원 탈퇴 기능을 Soft Delete 방식으로 구현했습니다. 탈퇴한 회원은 memberStatus가 DELETED로 변경되며, 모든 인증 및 로그인 플로우에서 자동으로 차단됩니다. 
- 탈퇴 후 같은 이메일/닉네임으로 재가입이 가능합니다.

### Changes

#### Core Implementation
- MemberEntity: deletedAt 필드, withdraw(), isDeleted() 메서드 추가
- MemberRepository: 탈퇴 회원 제외 쿼리 메서드 추가 (findByEmailAndMemberStatusNot
등)
- MyPageService: Hard Delete → Soft Delete로 변경

#### Security & Authentication
- 모든 로그인/인증 플로우에서 탈퇴 회원 필터링 적용
  - 이메일 로그인, OAuth 로그인 (Google, Naver, Kakao)
  - 회원가입 중복 체크, 비밀번호 재설정
  - JWT 인증 (CustomUserDetailService)

### Technical Details

- 방식: Soft Delete (memberStatus = DELETED)
- 재가입: 탈퇴 후 동일 이메일/닉네임으로 재가입 가능
- 보안: JWT 필터에서 탈퇴 회원 자동 차단

### Test Plan

- 회원 탈퇴 시 memberStatus가 DELETED로 변경되는지 확인
- 탈퇴 후 로그인 시도 시 차단되는지 확인
- 탈퇴 후 같은 이메일로 재가입 가능한지 확인
- MyPageServiceTest 수정 (delete → save 검증)